### PR TITLE
Use std::vector instead of QLinkedList

### DIFF
--- a/src/alarm_item.cpp
+++ b/src/alarm_item.cpp
@@ -6,28 +6,28 @@ WarningAlarmMonitor *DeviceAlarms::addTripplet(const QString &description, const
 {
 	WarningAlarmMonitor *ret = new WarningAlarmMonitor(mService, AlarmMonitor::REGULAR, busitemPathAlarm,
 										 description, busitemSetting, busitemPathValue, this);
-	mAlarms.append(ret);
+	mAlarms.push_back(ret);
 	return ret;
 }
 
 void DeviceAlarms::addVebusError(const QString &busitemPathAlarm)
 {
-	mAlarms.append(new AlarmMonitor(mService, AlarmMonitor::VEBUS_ERROR, busitemPathAlarm, "", nullptr, "", this));
+	mAlarms.push_back(new AlarmMonitor(mService, AlarmMonitor::VEBUS_ERROR, busitemPathAlarm, "", nullptr, "", this));
 }
 
 void DeviceAlarms::addBmsError(const QString &busitemPathAlarm)
 {
-	mAlarms.append(new AlarmMonitor(mService, AlarmMonitor::BMS_ERROR, busitemPathAlarm, "", nullptr, "", this));
+	mAlarms.push_back(new AlarmMonitor(mService, AlarmMonitor::BMS_ERROR, busitemPathAlarm, "", nullptr, "", this));
 }
 
 void DeviceAlarms::addChargerError(const QString &busitemPathAlarm)
 {
-	mAlarms.append(new AlarmMonitor(mService, AlarmMonitor::CHARGER_ERROR, busitemPathAlarm, "", nullptr, "", this));
+	mAlarms.push_back(new AlarmMonitor(mService, AlarmMonitor::CHARGER_ERROR, busitemPathAlarm, "", nullptr, "", this));
 }
 
 void DeviceAlarms::addWakespeedError(const QString &busitemPathAlarm)
 {
-	mAlarms.append(new AlarmMonitor(mService, AlarmMonitor::WAKESPEED_ERROR, busitemPathAlarm, "", nullptr, "", this));
+	mAlarms.push_back(new AlarmMonitor(mService, AlarmMonitor::WAKESPEED_ERROR, busitemPathAlarm, "", nullptr, "", this));
 }
 
 DeviceAlarms *DeviceAlarms::createBatteryAlarms(VenusService *service, Notifications *notications)

--- a/src/alarm_item.hpp
+++ b/src/alarm_item.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QObject>
-#include <QLinkedList>
 
 #include <veutil/qt/ve_qitem.hpp>
 
@@ -49,7 +48,7 @@ public:
 
 protected:
 	VenusService *mService;
-	QLinkedList<AlarmMonitor *> mAlarms;
+	std::vector<AlarmMonitor *> mAlarms;
 	Notifications *mNotifications;
 };
 


### PR DESCRIPTION
The venus-platform project has a singular dependence on a QLinkedList class that appears to live in the victronenergy/qt project. It's the only external dependence outside of victronenergy/veutil project and if I had to make an educated guess it's some oversight from making the venus-platform project public? Seeing that std::vector is already being used in gui-v2 and veutil it seems to be a natural replacement.

Result: The venus-platform project can be compiled upon git checkout without setting up magic build paths.